### PR TITLE
Wrong text alignment

### DIFF
--- a/streetLabel/client.lua
+++ b/streetLabel/client.lua
@@ -80,7 +80,7 @@ Citizen.CreateThread(function()
 					if tostring(GetStreetNameFromHashKey(var2)) == "" then
 						drawTxt2(x-0.275, y+0.45, 1.0,1.0,0.45, current_zone, town_r, town_g, town_b, town_a)
 					else 
-						drawTxt2(x-0.275, x+0.45, 1.0,1.0,0.45, tostring(GetStreetNameFromHashKey(var2)) .. ", " .. zones[GetNameOfZone(pos.x, pos.y, pos.z)], str_around_r, str_around_g, str_around_b, str_around_a)
+						drawTxt2(x-0.275, y+0.45, 1.0,1.0,0.45, tostring(GetStreetNameFromHashKey(var2)) .. ", " .. zones[GetNameOfZone(pos.x, pos.y, pos.z)], str_around_r, str_around_g, str_around_b, str_around_a)
 					end
 						drawTxt2(x-0.275, y+0.42, 1.0,1.0,0.55, tostring(GetStreetNameFromHashKey(var1)), curr_street_r, curr_street_g, curr_street_b, curr_street_a)
 				elseif direction == 'S' then


### PR DESCRIPTION
Fixes a small typo, this resulted in wrong position if x and y arguments were different and player was looking in SE direction.